### PR TITLE
fix(document): ignore fields with None value

### DIFF
--- a/mongoengine_goodjson/document.py
+++ b/mongoengine_goodjson/document.py
@@ -107,7 +107,7 @@ class Helper(object):
                 if isinstance(obj, list):
                     for item in obj:
                         item.begin_goodjson()
-                else:
+                elif obj is not None:
                     obj.begin_goodjson(cur_depth)
 
         @set_flag_recursive.register(FollowReferenceField)
@@ -141,7 +141,7 @@ class Helper(object):
                 if isinstance(obj, list):
                     for item in obj:
                         item.end_goodjson()
-                else:
+                elif obj is not None:
                     obj.end_goodjson(cur_depth)
 
         @unset_flag_recursive.register(FollowReferenceField)


### PR DESCRIPTION
Before:

When we have an EmbeddedDocumentField and any field is null, this prints:

```
File "/usr/local/lib/python3.5/site-packages/mongoengine_goodjson/document.py", line 111, in set_flag_emb
    obj.begin_goodjson(cur_depth)
AttributeError: 'NoneType' object has no attribute 'begin_goodjson'
```

After:
Ignore the fields with values null.