### PR TITLE
Added encoder support for SON objects

### DIFF
--- a/mongoengine_goodjson/encoder.py
+++ b/mongoengine_goodjson/encoder.py
@@ -15,7 +15,7 @@ from .utils import method_dispatch, id_first
 
 from bson import (
     ObjectId, DBRef, RE_TYPE, Regex, MinKey, MaxKey, Timestamp, Code, Binary,
-    PY3
+    PY3, SON
 )
 from bson.py3compat import text_type, string_type
 
@@ -110,6 +110,10 @@ class GoodJSONEncoder(json.JSONEncoder):
     @default.register(Code)
     def __conv_code(self, obj):
         return {"code": str(obj), "scope": obj.scope}
+
+    @default.register(SON)
+    def _conv_son(self, obj):
+        return obj.to_dict()
 
     @default.register(Binary)
     def __conv_bin(self, obj):

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -392,6 +392,21 @@ class CodeTest(TestCase):
         self.assertDictEqual(self.expected, self.encoder.default(self.data))
 
 
+class SONTest(TestCase):
+    """SON test."""
+
+    def setUp(self):
+        """Set up class."""
+        from bson.son import SON
+        self.encoder = GoodJSONEncoder()
+        self.expected = {"data": "test"}
+        self.data = SON(data={"data": "test"})
+
+    def test_son(self):
+        """SON data should be expected value"""
+        self.assertDictEqual(self.expected, self.encoder.default(self.data))
+
+
 class BinaryTest(TestCase):
     """Binary test."""
 


### PR DESCRIPTION
Hello ! It's me again :)

I was encountering a bug when trying to serialize a document with a compound primary key. The exception was "TypeError: Object of type SON is not JSON serializable".

It turns out that I just needed to implement a specific encoder in GoodJSONEncoder.

I added a unit test for this new addition.